### PR TITLE
Upgrade plist package

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,14 +3,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:cefe687c5b27365f87dff523c85266408415c62a2915cc6148e9c26861274984"
-  name = "github.com/DHowett/go-plist"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "500bd5b9081b5957ac10389f86e069869f00c348"
-
-[[projects]]
-  branch = "master"
   digest = "1:315c5f2f60c76d89b871c73f9bd5fe689cad96597afd50fb9992228ef80bdd34"
   name = "github.com/alecthomas/template"
   packages = [
@@ -84,15 +76,23 @@
   revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
   version = "v2.2.6"
 
+[[projects]]
+  branch = "master"
+  digest = "1:c10265d5a71326618d37e97169eddb3582f78e8ac7dcf87403b4cf619efd519a"
+  name = "howett.net/plist"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "591f970eefbbeb04d7b37f334a0c4c3256e32876"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/DHowett/go-plist",
     "github.com/fatih/color",
     "github.com/juju/deputy",
     "github.com/mattn/go-sqlite3",
     "gopkg.in/alecthomas/kingpin.v2",
+    "howett.net/plist",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/DHowett/go-plist"
+  name = "howett.net/plist"
 
 [[constraint]]
   name = "github.com/fatih/color"

--- a/safari.go
+++ b/safari.go
@@ -32,7 +32,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DHowett/go-plist"
+	"howett.net/plist"
 )
 
 // Types of entries in Bookmarks.plist.


### PR DESCRIPTION
This upgrades the plist package which includes these changes: https://github.com/DHowett/go-plist/compare/500bd5b9081b5957ac10389f86e069869f00c348...591f970eefbbeb04d7b37f334a0c4c3256e32876

Specifically, DHowett/go-plist@591f970eefbbeb04d7b37f334a0c4c3256e32876 added a go.mod file which enforced the canonical import path and this package seems to instead have referenced the repository directly. This breaks `go mod`.

You can reproduce by creating any main.go file that references this package:

    package main

    import _ "github.com/deanishe/go-safari"

    func main() {
    }

Initialize a new module:

    $ go mod init example
    go: creating new go.mod: module example

Run `go mod why` which will now fail with:

    ...
    go: github.com/DHowett/go-plist@v0.0.0-20181124034731-591f970eefbb: parsing go.mod: unexpected module path "howett.net/plist"
    go: error loading module requirements

An alternative to upgrading the dependency is to add a go.mod file in this repository which instructs `go.mod` to use the version before the import path changed.